### PR TITLE
Add detected changes to new template to preserve source template Resource dict integrity.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,14 +20,17 @@ def recursiveFindReplaceText(obj, text, replace):
 
 def replaceWaitConditionLogicalIds(template, paramHash):
 
+    newTemplate = template
     changes = []
     for logicalId, resource in template['Resources'].items():
         if resource['Type'] in ["AWS::CloudFormation::WaitConditionHandle", "AWS::CloudFormation::WaitCondition"] and not logicalId.endswith(paramHash):
             newId = logicalId+paramHash
-            template['Resources'][newId] = template['Resources'].pop(logicalId)
             changes.append((logicalId, newId))
 
-    return template, changes
+    for change in changes:
+        newTemplate['Resources'][change[1]] = template['Resources'].pop(change[0])
+
+    return newTemplate, changes
 
 def handler(event, context):
 


### PR DESCRIPTION
Noticed when running the macro on a subset of some of my ECS Services that occasionally ServiceWaitCondition would never receive a paramHash update. After testing and adding some logs I realized it was never getting evaluated while looping over the Resources after the ServiceWaitHandle gets a hash.

This change allows for the new hashed handler/condition resources to not get added back to the original dict we're looking at so that the ServiceWaitCondition resource doesn't get occasionally skipped.